### PR TITLE
Fix React 19 compatibility: Update lucide-react and recharts versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "homepage": "https://drdedge.github.io/clock-learning-app",
   "dependencies": {
     "cra-template-tailwindcss": "4.0.1",
-    "lucide-react": "^0.263.1",
+    "lucide-react": "^0.460.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-scripts": "5.0.1",
-    "recharts": "^2.12.7",
+    "recharts": "^2.14.1",
     "web-vitals": "^4.2.4"
   },
   "scripts": {


### PR DESCRIPTION
- Updated lucide-react from 0.263.1 to 0.460.0 for React 19 support
- Updated recharts from 2.12.7 to 2.14.1 for better React 19 compatibility

The previous versions had peer dependency conflicts with React 19.

🤖 Generated with [Claude Code](https://claude.ai/code)