### PR TITLE
Expand math question generators

### DIFF
--- a/public/images/bar-chart-aeroplanes.svg
+++ b/public/images/bar-chart-aeroplanes.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="150" viewBox="0 0 200 150">
+  <rect width="200" height="150" fill="white" />
+  <rect x="40" y="60" width="30" height="70" fill="#90caf9" />
+  <rect x="90" y="30" width="30" height="100" fill="#f48fb1" />
+  <rect x="140" y="90" width="30" height="40" fill="#a5d6a7" />
+  <text x="55" y="140" font-size="12" text-anchor="middle">A</text>
+  <text x="105" y="140" font-size="12" text-anchor="middle">B</text>
+  <text x="155" y="140" font-size="12" text-anchor="middle">C</text>
+</svg>

--- a/public/images/fraction-half.svg
+++ b/public/images/fraction-half.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <circle cx="40" cy="40" r="35" fill="#fde68a" stroke="#444" stroke-width="2" />
+  <path d="M40 5 A35 35 0 0 1 75 40 L40 40 Z" fill="#f59e0b" />
+</svg>

--- a/public/images/fraction-quarter.svg
+++ b/public/images/fraction-quarter.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <circle cx="40" cy="40" r="35" fill="#fde68a" stroke="#444" stroke-width="2" />
+  <path d="M40 40 L40 5 A35 35 0 0 1 75 40 Z" fill="#f59e0b" />
+</svg>

--- a/public/images/fraction-third.svg
+++ b/public/images/fraction-third.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <circle cx="40" cy="40" r="35" fill="#fde68a" stroke="#444" stroke-width="2" />
+  <path d="M40 40 L40 5 A35 35 0 0 1 62 15 L40 40 Z" fill="#f59e0b" />
+</svg>

--- a/public/images/fraction-three-quarters.svg
+++ b/public/images/fraction-three-quarters.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <circle cx="40" cy="40" r="35" fill="#fde68a" stroke="#444" stroke-width="2" />
+  <path d="M40 40 L40 5 A35 35 0 0 1 75 40 L40 40 Z" fill="#f59e0b" />
+  <path d="M40 40 L75 40 A35 35 0 0 1 40 75 Z" fill="#f59e0b" />
+</svg>

--- a/public/images/pencil-ruler.svg
+++ b/public/images/pencil-ruler.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="80" viewBox="0 0 300 80">
+  <rect x="10" y="40" width="280" height="10" fill="#ddd" />
+  <line x1="20" y1="40" x2="20" y2="50" stroke="#333" stroke-width="1" />
+  <line x1="40" y1="40" x2="40" y2="50" stroke="#333" stroke-width="1" />
+  <line x1="60" y1="40" x2="60" y2="50" stroke="#333" stroke-width="1" />
+  <line x1="80" y1="40" x2="80" y2="50" stroke="#333" stroke-width="1" />
+  <line x1="100" y1="40" x2="100" y2="50" stroke="#333" stroke-width="1" />
+  <rect x="50" y="20" width="180" height="15" fill="#f4a261" />
+  <polygon points="230,20 250,27.5 230,35" fill="#e76f51" />
+  <rect x="230" y="20" width="20" height="15" fill="#264653" />
+</svg>

--- a/src/components/pages/SevenPlusQuizApp.js
+++ b/src/components/pages/SevenPlusQuizApp.js
@@ -361,6 +361,7 @@ const SevenPlusQuizApp = () => {
                             <option value="measurement">Measurement & Units</option>
                             <option value="money">Money & Change</option>
                             <option value="mentalMath">Mental Math Strategies</option>
+                            <option value="fractions">Fractions</option>
                         </select>
                     </div>
 

--- a/src/utils/questions/fractions.js
+++ b/src/utils/questions/fractions.js
@@ -1,0 +1,60 @@
+// Fractions Question Generators
+
+const FRACTION_IMAGES = [
+    { fraction: "1/2", image: "/images/fraction-half.svg" },
+    { fraction: "1/3", image: "/images/fraction-third.svg" },
+    { fraction: "1/4", image: "/images/fraction-quarter.svg" },
+    { fraction: "3/4", image: "/images/fraction-three-quarters.svg" }
+];
+
+const FRACTION_OPTIONS = ["1/2", "1/3", "1/4", "3/4"];
+
+export const simpleFractions = () => {
+    const choice = FRACTION_IMAGES[Math.floor(Math.random() * FRACTION_IMAGES.length)];
+    const options = [...FRACTION_OPTIONS];
+
+    return {
+        question: "What fraction of the shape is shaded?",
+        image: choice.image,
+        options,
+        answer: options.indexOf(choice.fraction),
+        correctAnswer: choice.fraction,
+        category: "Fractions",
+        skill: "Recognising simple fractions",
+        tip: "Count the shaded parts out of the whole",
+        inputType: "multiple-choice"
+    };
+};
+
+export const comparingFractions = () => {
+    const [a, b] = [
+        FRACTION_OPTIONS[Math.floor(Math.random() * FRACTION_OPTIONS.length)],
+        FRACTION_OPTIONS[Math.floor(Math.random() * FRACTION_OPTIONS.length)]
+    ];
+    if (a === b) return comparingFractions();
+
+    const toValue = (f) => {
+        const [n, d] = f.split('/').map(Number);
+        return n / d;
+    };
+    const askBigger = Math.random() > 0.5;
+    const correct = askBigger ? (toValue(a) > toValue(b) ? a : b) : (toValue(a) < toValue(b) ? a : b);
+
+    return {
+        question: `Which fraction is ${askBigger ? 'larger' : 'smaller'}: ${a} or ${b}?`,
+        options: [a, b],
+        answer: [a, b].indexOf(correct),
+        correctAnswer: correct,
+        category: "Fractions",
+        skill: "Comparing fractions",
+        tip: "Think about how much of the whole each fraction represents",
+        inputType: "multiple-choice"
+    };
+};
+
+const fractionGenerators = {
+    simpleFractions,
+    comparingFractions
+};
+
+export default fractionGenerators;

--- a/src/utils/questions/index.js
+++ b/src/utils/questions/index.js
@@ -7,6 +7,7 @@ import shapes from './shapes';
 import measurement from './measurement';
 import numberBonds from './numberBonds';
 import mentalMath from './mentalMath';
+import fractions from './fractions';
 
 // Combine all generators into a single object
 export const questionGenerators = {
@@ -30,9 +31,12 @@ export const questionGenerators = {
     
     // Number Bonds
     ...numberBonds,
-    
+
     // Mental Math
-    ...mentalMath
+    ...mentalMath,
+
+    // Fractions
+    ...fractions
 };
 
 // Category mappings for focus modes
@@ -44,7 +48,8 @@ export const categoryGenerators = {
     shapes: Object.keys(shapes),
     measurement: Object.keys(measurement),
     numberBonds: Object.keys(numberBonds),
-    mentalMath: Object.keys(mentalMath)
+    mentalMath: Object.keys(mentalMath),
+    fractions: Object.keys(fractions)
 };
 
 // Get generators for a specific focus mode
@@ -66,6 +71,8 @@ export const getGeneratorsForFocusMode = (focusMode) => {
             return categoryGenerators.moneyProblems;
         case 'mentalMath':
             return categoryGenerators.mentalMath;
+        case 'fractions':
+            return categoryGenerators.fractions;
         default:
             // Return all generators for 'all' mode
             return Object.keys(questionGenerators);
@@ -81,5 +88,6 @@ export {
     shapes,
     measurement,
     numberBonds,
-    mentalMath
+    mentalMath,
+    fractions
 };

--- a/src/utils/questions/measurement.js
+++ b/src/utils/questions/measurement.js
@@ -98,6 +98,32 @@ export const unitConversion = () => {
     };
 };
 
+export const centimetersInMeters = () => {
+    const meters = Math.floor(Math.random() * 9) + 2; // 2-10m
+
+    return {
+        question: `How many centimeters are in ${meters} meters?`,
+        answer: meters * 100,
+        category: "Measurement",
+        skill: "Unit conversion",
+        tip: "Multiply the meters by 100 to get centimeters",
+        inputType: "number"
+    };
+};
+
+export const metersInKilometers = () => {
+    const km = Math.floor(Math.random() * 9) + 1; // 1-9km
+
+    return {
+        question: `How many meters are in ${km} kilometers?`,
+        answer: km * 1000,
+        category: "Measurement",
+        skill: "Unit conversion",
+        tip: "1km = 1000m",
+        inputType: "number"
+    };
+};
+
 export const comparingMeasurements = () => {
     const comparisons = [
         {
@@ -143,6 +169,8 @@ const measurementGenerators = {
     timeEstimation,
     massComparison,
     unitConversion,
+    centimetersInMeters,
+    metersInKilometers,
     comparingMeasurements
 };
 

--- a/src/utils/questions/measurement.js
+++ b/src/utils/questions/measurement.js
@@ -163,6 +163,21 @@ export const comparingMeasurements = () => {
     };
 };
 
+export const pencilLengthImage = () => {
+    const options = ["5cm", "10cm", "15cm", "20cm"];
+    return {
+        question: "How long is the pencil in the picture?",
+        image: "/images/pencil-ruler.svg",
+        options,
+        answer: 2,
+        correctAnswer: "15cm",
+        category: "Measurement",
+        skill: "Reading a ruler",
+        tip: "Count the centimetre marks on the ruler",
+        inputType: "multiple-choice"
+    };
+};
+
 // Export all generators for this category
 const measurementGenerators = {
     measurementComparison,
@@ -171,7 +186,8 @@ const measurementGenerators = {
     unitConversion,
     centimetersInMeters,
     metersInKilometers,
-    comparingMeasurements
+    comparingMeasurements,
+    pencilLengthImage
 };
 
 export default measurementGenerators;

--- a/src/utils/questions/numberBonds.js
+++ b/src/utils/questions/numberBonds.js
@@ -130,13 +130,41 @@ export const missingNumber = () => {
     };
 };
 
+export const balancingEquation = () => {
+    const a = Math.floor(Math.random() * 10) + 5; // 5-14
+    const b = Math.floor(Math.random() * 10) + 5;
+    const c = Math.floor(Math.random() * 8) + 2;
+    const type = Math.random() > 0.5;
+
+    let question, answer;
+    if (type) {
+        // a + b = ___ + c
+        question = `${a} + ${b} = ___ + ${c}`;
+        answer = a + b - c;
+    } else {
+        // a + ___ = b + c
+        question = `${a} + ___ = ${b} + ${c}`;
+        answer = b + c - a;
+    }
+
+    return {
+        question: `Solve: ${question}`,
+        answer,
+        category: "Number Bonds",
+        skill: "Balancing equations",
+        tip: "Both sides of the equation must have the same total",
+        inputType: "number"
+    };
+};
+
 // Export all generators for this category
 const numberBondsGenerators = {
     numberBondsTo10,
     numberBondsTo20,
     numberBondsTo50,
     numberBondsTo100,
-    missingNumber
+    missingNumber,
+    balancingEquation
 };
 
 export default numberBondsGenerators;

--- a/src/utils/questions/wordProblems.js
+++ b/src/utils/questions/wordProblems.js
@@ -127,12 +127,28 @@ export const handshakeProblem = () => {
     };
 };
 
+export const barChartAeroplanes = () => {
+    const options = ["Alice", "Ben", "Cara"];
+    return {
+        question: "Who made the most paper aeroplanes?",
+        image: "/images/bar-chart-aeroplanes.svg",
+        options,
+        answer: 1,
+        correctAnswer: "Ben",
+        category: "Word Problems",
+        skill: "Interpreting bar charts",
+        tip: "Look for the tallest bar",
+        inputType: "multiple-choice"
+    };
+};
+
 // Export all generators for this category
 const wordProblemsGenerators = {
     simpleAdditionStory,
     subtractionStory,
     comparisonProblem,
-    handshakeProblem
+    handshakeProblem,
+    barChartAeroplanes
 };
 
 export default wordProblemsGenerators;

--- a/src/utils/questions/wordProblems.js
+++ b/src/utils/questions/wordProblems.js
@@ -39,6 +39,12 @@ const NAMES = [
     "Ben", "Amy", "Leo", "Eva", "Max", "Isla", "Sam", "Ella"
 ];
 
+const HANDSHAKE_CONTEXTS = [
+    { place: "at a party", group: "friends" },
+    { place: "on a team", group: "players" },
+    { place: "in a meeting", group: "people" }
+];
+
 export const simpleAdditionStory = () => {
     const scenario = SCENARIOS.addition[Math.floor(Math.random() * SCENARIOS.addition.length)];
     const item = scenario.items[Math.floor(Math.random() * scenario.items.length)];
@@ -106,11 +112,27 @@ export const comparisonProblem = () => {
     };
 };
 
+export const handshakeProblem = () => {
+    const context = HANDSHAKE_CONTEXTS[Math.floor(Math.random() * HANDSHAKE_CONTEXTS.length)];
+    const friends = Math.floor(Math.random() * 3) + 4; // 4-6
+    const handshakes = (friends * (friends - 1)) / 2;
+
+    return {
+        question: `There are ${friends} ${context.group} ${context.place}. If each one shakes hands with every other once, how many handshakes happen in total?`,
+        answer: handshakes,
+        category: "Word Problems",
+        skill: "Counting combinations",
+        tip: "Use n(n-1)/2 to count all unique handshakes",
+        inputType: "number"
+    };
+};
+
 // Export all generators for this category
 const wordProblemsGenerators = {
     simpleAdditionStory,
     subtractionStory,
-    comparisonProblem
+    comparisonProblem,
+    handshakeProblem
 };
 
 export default wordProblemsGenerators;


### PR DESCRIPTION
## Summary
- add measurement conversion questions
- add handshake counting word problem
- generate missing-value balanced equations

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684035396804832392528613729f0797